### PR TITLE
Fixes "min" when dropping dice

### DIFF
--- a/internal/dicelang/interpreter.go
+++ b/internal/dicelang/interpreter.go
@@ -593,10 +593,11 @@ func (d *Dice) Roll() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	d.Min = d.Count
 	if d.DropHighest > 0 || d.DropLowest > 0 {
+		d.Min = d.Count - (d.DropHighest + d.DropLowest)
 		d.Max = (d.Count - (d.DropHighest + d.DropLowest)) * d.Sides
 	} else {
+		d.Min = d.Count
 		d.Max = d.Count * d.Sides
 	}
 	d.Faces = faces

--- a/internal/dicelang/interpreter_test.go
+++ b/internal/dicelang/interpreter_test.go
@@ -185,37 +185,33 @@ func testRoll(t *testing.T, biasMod int64, biasTo int64, biasFreq float64, loops
 
 func TestMinMaxValues(t *testing.T) {
 	type testCase struct {
-		name string
-		nDice int64
-		nSides int64
-		dropHigh int64
-		dropLow int64
+		cmd string
 		expectedMin int64
 		expectedMax int64
 	}
 	tests := []testCase {
 		{
-			name: "1d4", // one die
+			cmd: "1d4", // one die
 			expectedMin: 1,
 			expectedMax: 4,
 		},
 		{
-			name: "2d4", // two dice
+			cmd: "2d4", // two dice
 			expectedMin: 2,
 			expectedMax: 8,
 		},
 		{
-			name: "2d4-L", // drop lowest
+			cmd: "2d4-L", // drop lowest
 			expectedMin: 1,
 			expectedMax: 4,
 		},
 		{
-			name: "2d4-H", // drop highest
+			cmd: "2d4-H", // drop highest
 			expectedMin: 1,
 			expectedMax: 4,
 		},
 		{
-			name: "20d4-H5", // drop multiple
+			cmd: "20d4-H5", // drop multiple
 			expectedMin: 15,
 			expectedMax: 60,
 		},

--- a/internal/dicelang/interpreter_test.go
+++ b/internal/dicelang/interpreter_test.go
@@ -182,3 +182,56 @@ func testRoll(t *testing.T, biasMod int64, biasTo int64, biasFreq float64, loops
 	}
 	return false, nil
 }
+
+func TestMinMaxValues(t *testing.T) {
+	type testCase struct {
+		name string
+		nDice int64
+		nSides int64
+		dropHigh int64
+		dropLow int64
+		expectedMin int64
+		expectedMax int64
+	}
+	tests := []testCase {
+		{
+			name: "1d4", // one die
+			expectedMin: 1,
+			expectedMax: 4,
+		},
+		{
+			name: "2d4", // two dice
+			expectedMin: 2,
+			expectedMax: 8,
+		},
+		{
+			name: "2d4-L", // drop lowest
+			expectedMin: 1,
+			expectedMax: 4,
+		},
+		{
+			name: "2d4-H", // drop highest
+			expectedMin: 1,
+			expectedMax: 4,
+		},
+		{
+			name: "20d4-H5", // drop multiple
+			expectedMin: 15,
+			expectedMax: 60,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParser(tt.name)
+			stmts, err := p.Statements()
+			_ , diceSet, err := stmts.GetDiceSet()
+			if err != nil {
+				t.Errorf("There was an error parsing a test case: %v", tt.name)
+			}
+			dice := diceSet.Dice[0]
+			if dice.Min != tt.expectedMin || dice.Max != tt.expectedMax {
+				t.Errorf("Min or Max does not match. Expected: min == %v, max == %v | got: min == %v max == %v", tt.expectedMin, tt.expectedMax, dice.Min, dice.Max)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The dicelang interpreter correctly accounts for dropping dice when it calculates "max" for a diceset. It must do the same for "min" !!

Steps to repro:
1. roll 2d20-H
2. inspect the value of the roll response. It will indicate that the min value is 2 and the max value is 20.